### PR TITLE
Add raw params in base params and prepared params

### DIFF
--- a/thrall/amap/_models/_base_model.py
+++ b/thrall/amap/_models/_base_model.py
@@ -84,11 +84,13 @@ class BaseRequestParams(object):
     ROUTE_KEY = RouteKey.UNKNOWN
 
     @required_params('key')
-    def __init__(self, key=None, output=None, private_key=None, callback=None):
+    def __init__(self, key=None, output=None, private_key=None, callback=None,
+                 raw_params=None):
         self.key = key
         self.output = output
         self.callback = callback
         self.private_key = private_key
+        self._raw_params = raw_params
 
     def prepare(self):
         try:
@@ -120,7 +122,8 @@ class BaseRequestParams(object):
         new_fun = functools.partial(p.prepare, key=self.key,
                                     pkey=self.private_key,
                                     output=self.output,
-                                    callback=self.callback, )
+                                    callback=self.callback,
+                                    raw_params=self._raw_params)
         p.prepare = new_fun
         yield p
         p.prepare = org_fun
@@ -135,6 +138,7 @@ class BasePreparedRequestParams(object):
         self._pkey = None
         self.output = None
         self.callback = None
+        self._raw_params = None
 
     def __unicode__(self):
         params = [k for k, v in iteritems(self.__dict__) if
@@ -186,8 +190,10 @@ class BasePreparedRequestParams(object):
         """
         raise NotImplementedError
 
-    def prepare_base(self, key=None, pkey=None, output=None, callback=None):
+    def prepare_base(self, key=None, pkey=None, output=None, callback=None,
+                     raw_params=None):
         self._pkey = pkey
+        self._raw_params = raw_params
         self.prepare_key(key)
         self.prepare_output(output)
         self.prepare_callback(callback)
@@ -242,9 +248,11 @@ class BasePreparedRequestParams(object):
     @contextlib.contextmanager
     def init_basic_params(self, params, optionals=None):
         new_params = self._init_basic_params(params)
-        yield new_params
-
         self._init_optional_params(params, optionals)
+        # init raw_params
+        self._init_optional_params(params, self._raw_params)
+
+        yield new_params
 
     def _init_basic_params(self, params):
         params['key'] = self.prepared_key


### PR DESCRIPTION
## Description
add raw params support

usage: 
`session.search_text(city=u'北京', raw_params=dict(keywords=u'上海|美食')).data[0]`

request url: `http://restapi.amap.com/v3/place/text?keywords=%E4%B8%8A%E6%B5%B7%7C%E7%BE%8E%E9%A3%9F&city=%E5%8C%97%E4%BA%AC&key=...`

## Todos
- [x] Tests
- [ ] Change log

