### PR TITLE
move amap base modules to project base module.

### DIFF
--- a/tests/test_amap/test_models.py
+++ b/tests/test_amap/test_models.py
@@ -103,7 +103,7 @@ class TestBaseResponseDataNoImplement(object):
         with pytest.raises(NotImplementedError):
             raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
              "count": "1", "geocodes":[]}"""
-            model = _base_model.BaseResponseData(raw_data)
+            model = _base_model.AmapBaseResponseData(raw_data)
             model._get_data()
 
 
@@ -111,7 +111,7 @@ class TestBaseResponseData(object):
     def test_init_ok(self):
         raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
          "count": "1", "geocodes":[]}"""
-        model = _base_model.BaseResponseData(raw_data)
+        model = _base_model.AmapBaseResponseData(raw_data)
         assert model.status == 1
         assert isinstance(model.status, StatusFlag)
         assert model.status_msg.code == 10000
@@ -126,7 +126,7 @@ class TestBaseResponseData(object):
     def test_repr(self):
         raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
          "count": "1", "geocodes":[]}"""
-        model = _base_model.BaseResponseData(raw_data)
+        model = _base_model.AmapBaseResponseData(raw_data)
 
         for i in ['status=', 'status_msg=', 'count=', 'version=']:
             assert i in repr(model)
@@ -134,7 +134,7 @@ class TestBaseResponseData(object):
     def test_init_no_count(self):
         raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
          "geocodes":[]}"""
-        model = _base_model.BaseResponseData(raw_data)
+        model = _base_model.AmapBaseResponseData(raw_data)
         assert model.status == 1
         assert model.status_msg.code == 10000
         assert model.status_msg.msg == 'OK'
@@ -147,7 +147,7 @@ class TestBaseResponseData(object):
     def test_init_err(self):
         raw_data = """{"status": "0", "info": "INVALID_USER_KEY",
          "infocode": "10001"}"""
-        model = _base_model.BaseResponseData(raw_data)
+        model = _base_model.AmapBaseResponseData(raw_data)
         assert model.status == 0
         assert model.status_msg.code == 10001
         assert model.status_msg.msg == 'INVALID_USER_KEY'
@@ -160,7 +160,7 @@ class TestBaseResponseData(object):
 
     def test_init_v4_ok(self):
         raw_data = '{"errcode": 0, "errdetail": null, "errmsg": "OK"}'
-        model = _base_model.BaseResponseData(raw_data, AMapVersion.V4)
+        model = _base_model.AmapBaseResponseData(raw_data, AMapVersion.V4)
         assert model.status == 1
         assert model.status_msg.code == 0
         assert model.status_msg.msg == 'OK'
@@ -172,7 +172,7 @@ class TestBaseResponseData(object):
         raw_data = """{"errcode": 30006,
         "errdetail": "您输入的起点信息有误,请检验是否符合接口使用规范",
         "errmsg": "INVALID_PARAMETER_VALUE"}"""
-        model = _base_model.BaseResponseData(raw_data, AMapVersion.V4)
+        model = _base_model.AmapBaseResponseData(raw_data, AMapVersion.V4)
         assert model.status == 0
         assert model.status_msg.code == 30006
         assert model.status_msg.msg == 'INVALID_PARAMETER_VALUE'
@@ -182,7 +182,7 @@ class TestBaseResponseData(object):
 
     def test_auto_check_version(self):
         raw_data = '{"errcode": 0, "errdetail": null, "errmsg": "OK"}'
-        meta_model = _base_model.BaseResponseData
+        meta_model = _base_model.AmapBaseResponseData
 
         version = meta_model.auto_check_version(raw_data, AMapVersion.V3)
 
@@ -191,7 +191,7 @@ class TestBaseResponseData(object):
     def test_auto_check_version_init(self):
         raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
          "count": "1", "geocodes":[]}"""
-        model = _base_model.BaseResponseData(raw_data, auto_version=True)
+        model = _base_model.AmapBaseResponseData(raw_data, auto_version=True)
         assert model.status == 1
         assert model.status_msg.code == 10000
         assert model.status_msg.msg == 'OK'
@@ -201,7 +201,7 @@ class TestBaseResponseData(object):
 
     def test_auto_check_version_v4_init(self):
         raw_data = '{"errcode": 0, "errdetail": null, "errmsg": "OK"}'
-        model = _base_model.BaseResponseData(raw_data, auto_version=True)
+        model = _base_model.AmapBaseResponseData(raw_data, auto_version=True)
         assert model.status == 1
         assert model.status_msg.code == 0
         assert model.status_msg.msg == 'OK'
@@ -210,7 +210,7 @@ class TestBaseResponseData(object):
         assert model.count == 0
 
     def test_init_with_static_mode(self, mocker):
-        class Mock(_base_model.BaseResponseData):
+        class Mock(_base_model.AmapBaseResponseData):
             def get_data(self, raw_data, static=False): return 123
 
         data = """{"status": "1", "info": "OK", "infocode": "10000",

--- a/tests/test_amap/test_models.py
+++ b/tests/test_amap/test_models.py
@@ -46,39 +46,11 @@ class TestExtensions(object):
         assert model.d == model._opt_options['d'] == []
 
 
-class TestBaseModelNoEmplement(object):
+class TestAMapBaseModelNoEmplement(object):
     def test_prepare(self):
         with pytest.raises(NotImplementedError):
             model = _base_model.BaseRequestParams(key='xxx')
             model.prepare()
-
-
-class TestBaseModel(object):
-    def test_base_request_params(self):
-        model = _base_model.BaseRequestParams(key='xxx')
-
-        assert model.key == 'xxx'
-        assert model.output == model.callback == model.private_key == model._raw_params is None
-
-    def test_base_request_params_no_key(self):
-        with pytest.raises(RuntimeError):
-            _base_model.BaseRequestParams(key=None)
-
-        with pytest.raises(RuntimeError):
-            _base_model.BaseRequestParams()
-
-    def test_base_request_catch_vendor_err(self):
-        class Mock(_base_model.BaseRequestParams):
-            def prepare_data(self):
-                raise VendorParamError('123')
-
-        model = Mock(key='xxx')
-
-        with pytest.raises(VendorParamError) as err:
-            model.prepare()
-
-        assert isinstance(err.value.data, model.__class__)
-        assert '123' in str(err.value)
 
 
 class TestBasePrepareModelNoEmplement(object):

--- a/tests/test_amap/test_models.py
+++ b/tests/test_amap/test_models.py
@@ -10,13 +10,13 @@ from thrall.exceptions import AMapStatusError
 
 class TestSig(object):
     def test_sig(self):
-        sig = _base_model.Sig('key', kwargs=dict(b=1, a=2, d=4, c=3))
+        sig = _base_model.AMapSig('key', kwargs=dict(b=1, a=2, d=4, c=3))
 
         assert sig.unhash_sig == 'a=2&b=1&c=3&d=4key'
         assert sig.hashed_sig is not None
 
     def test_repr(self):
-        sig = _base_model.Sig('key', kwargs=dict(b=1, a=2, d=4, c=3))
+        sig = _base_model.AMapSig('key', kwargs=dict(b=1, a=2, d=4, c=3))
 
         for i in ['AMapSig(', 'method=OPENSSL_MD5',
                   "sig='a=2&b=1&c=3&d=4key'"]:
@@ -91,7 +91,7 @@ class TestBasePrepareModel(object):
         model._pkey = 'hahaha'
         model.prepare_output('json')
 
-        assert isinstance(model.sig, _base_model.Sig)
+        assert isinstance(model.sig, _base_model.AMapSig)
 
         assert model.sig.private_key == model._pkey
         assert model.sig.unhash_sig == 'key=xxx&output=jsonhahaha'

--- a/tests/test_amap/test_session.py
+++ b/tests/test_amap/test_session.py
@@ -99,8 +99,8 @@ class TestAMapSession(object):
             model.mount('code', AMapEncodeAdapter)
 
     def prepare_hook(self, p):
-        from thrall.amap.models import BasePreparedRequestParams
-        assert isinstance(p, BasePreparedRequestParams)
+        from thrall.amap.models import AMapBasePreparedRequestParams
+        assert isinstance(p, AMapBasePreparedRequestParams)
 
     def repsonse_hook(self, r):
         from requests.models import Response

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -15,6 +15,7 @@ from thrall.base import (
     BaseData,
     BaseRequestParams,
     BasePreparedRequestParams,
+    BaseResponseData,
 )
 from thrall.consts import OutputFmt, FORMAT_XML, FORMAT_JSON
 
@@ -244,6 +245,34 @@ class TestBaseRequest(object):
 
         with pytest.raises(VendorHTTPError):
             model.get('http://example.com', None)
+
+
+class TestBaseResponseDataNoImplement(object):
+    @pytest.mark.parametrize('param', ['status', 'status_msg',
+                                       'count', 'data'])
+    def test_params(self, param):
+        with pytest.raises(NotImplementedError):
+            raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
+             "count": "1", "geocodes":[]}"""
+            model = BaseResponseData(raw_data, 0)
+            getattr(model, param)
+
+    def test_raise_for_status(self):
+        with pytest.raises(NotImplementedError):
+            raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
+             "count": "1", "geocodes":[]}"""
+            model = BaseResponseData(raw_data, 0)
+            model.raise_for_status()
+
+
+class TestBaseResponseData(object):
+    def test_init_ok(self):
+        raw_data = """{"status": "1", "info": "OK", "infocode": "10000",
+         "count": "1", "geocodes":[]}"""
+        model = BaseResponseData(raw_data, 0)
+
+        assert model.version == 0
+        assert model._raw_data == raw_data
 
 
 class TestBaseData(object):

--- a/thrall/amap/_models/__init__.py
+++ b/thrall/amap/_models/__init__.py
@@ -1,11 +1,13 @@
 # coding: utf-8
 from __future__ import absolute_import
 
+import logging as _log
+
 from ._base_model import (
     Sig,
     Extensions,
-    BaseRequestParams,
-    BasePreparedRequestParams,
+    AMapBaseRequestParams,
+    AMapBasePreparedRequestParams,
     BaseResponseData,
 )
 from ._common_model import (
@@ -80,7 +82,7 @@ from ._batch_model import (
 
 __all__ = [
     # base
-    "Sig", "BaseRequestParams", "BasePreparedRequestParams",
+    "Sig", "AMapBaseRequestParams", "AMapBasePreparedRequestParams",
     "BaseResponseData", "Extensions",
     # batch
     "BatchRequestParams", "PreparedBatchParams", "BatchResponseData",
@@ -115,4 +117,16 @@ __all__ = [
     "NaviDrivingRequestParams", "PreparedNaviDrivingRequestParams",
     "NaviDrivingResponseData", "NaviDrivingData", "DrivingPath",
     "DrivingSteps",
+    # deprecated module
+    "BaseRequestParams", "BasePreparedRequestParams",
 ]
+
+
+class BaseRequestParams(AMapBaseRequestParams):
+    _log.warning('"BaseRequestParams" move to base module, please '
+                 'import "AMapBaseRequestParams"')
+
+
+class BasePreparedRequestParams(AMapBasePreparedRequestParams):
+    _log.warning('"AMapBasePreparedRequestParams" move to base module, please '
+                 'import "AMapBasePreparedRequestParams"')

--- a/thrall/amap/_models/__init__.py
+++ b/thrall/amap/_models/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import logging as _logging
 
 from ._base_model import (
-    Sig,
+    AMapSig,
     Extensions,
     AMapBaseRequestParams,
     AMapBasePreparedRequestParams,
@@ -82,7 +82,7 @@ from ._batch_model import (
 
 __all__ = [
     # base
-    "Sig", "AMapBaseRequestParams", "AMapBasePreparedRequestParams",
+    "AMapSig", "AMapBaseRequestParams", "AMapBasePreparedRequestParams",
     "AmapBaseResponseData", "Extensions",
     # batch
     "BatchRequestParams", "PreparedBatchParams", "BatchResponseData",
@@ -144,3 +144,8 @@ class BaseResponseData(AmapBaseResponseData):
     def __new__(cls, *args, **kwargs):
         _log.warning(_TEMPATE.format(origin_module='BaseResponseData',
                                      this='AmapBaseResponseData'))
+
+
+class Sig(AMapSig):
+    def __new__(cls, *args, **kwargs):
+        _log.warning(_TEMPATE.format(origin_module='Sig', this='AmapSig'))

--- a/thrall/amap/_models/__init__.py
+++ b/thrall/amap/_models/__init__.py
@@ -1,14 +1,14 @@
 # coding: utf-8
 from __future__ import absolute_import
 
-import logging as _log
+import logging as _logging
 
 from ._base_model import (
     Sig,
     Extensions,
     AMapBaseRequestParams,
     AMapBasePreparedRequestParams,
-    BaseResponseData,
+    AmapBaseResponseData,
 )
 from ._common_model import (
     Neighborhood,
@@ -83,7 +83,7 @@ from ._batch_model import (
 __all__ = [
     # base
     "Sig", "AMapBaseRequestParams", "AMapBasePreparedRequestParams",
-    "BaseResponseData", "Extensions",
+    "AmapBaseResponseData", "Extensions",
     # batch
     "BatchRequestParams", "PreparedBatchParams", "BatchResponseData",
     # common
@@ -121,12 +121,26 @@ __all__ = [
     "BaseRequestParams", "BasePreparedRequestParams",
 ]
 
+_TEMPATE = ("'{origin_module}' rename to '{this}' and origin name "
+            "will be deprecate and reuse in more basic module, "
+            "please import new module: {this}")
+
+_log = _logging.getLogger(__name__)
+
 
 class BaseRequestParams(AMapBaseRequestParams):
-    _log.warning('"BaseRequestParams" move to base module, please '
-                 'import "AMapBaseRequestParams"')
+    def __new__(cls, *args, **kwargs):
+        _log.warning(_TEMPATE.format(origin_module='BasePreparedRequestParams',
+                                     this='AMapBaseRequestParams'))
 
 
 class BasePreparedRequestParams(AMapBasePreparedRequestParams):
-    _log.warning('"AMapBasePreparedRequestParams" move to base module, please '
-                 'import "AMapBasePreparedRequestParams"')
+    def __new__(cls, *args, **kwargs):
+        _log.warning(_TEMPATE.format(origin_module='BasePreparedRequestParams',
+                                     this='AMapBasePreparedRequestParams'))
+
+
+class BaseResponseData(AmapBaseResponseData):
+    def __new__(cls, *args, **kwargs):
+        _log.warning(_TEMPATE.format(origin_module='BaseResponseData',
+                                     this='AmapBaseResponseData'))

--- a/thrall/amap/_models/_base_model.py
+++ b/thrall/amap/_models/_base_model.py
@@ -8,9 +8,9 @@ from six import iteritems
 from thrall.base import (
     BaseRequestParams as B_RP,
     BasePreparedRequestParams as BP_RP,
+    BaseResponseData as B_RD,
 )
 from thrall.compat import unicode
-from thrall.consts import RouteKey
 from thrall.exceptions import amap_status_exception
 from thrall.utils import MapStatusMessage, repr_params
 
@@ -108,17 +108,15 @@ class AMapBasePreparedRequestParams(BP_RP):
             return self.sig.hashed_sig
 
 
-class BaseResponseData(object):
-    ROUTE_KEY = RouteKey.UNKNOWN
-
+class AmapBaseResponseData(B_RD):
     def __init__(self, raw_data, version=AMapVersion.V3,
                  auto_version=False, static_mode=False, raw_mode=False):
+        super(AmapBaseResponseData, self).__init__(raw_data=raw_data,
+                                                   version=version)
 
-        if raw_mode:
-            self._raw_data = raw_data
-        else:
+        if not raw_mode:
             self._raw_data = json_load_and_fix_amap_empty(raw_data)
-        self.version = version
+
         self._data = None
 
         if auto_version:
@@ -127,13 +125,6 @@ class BaseResponseData(object):
 
         if static_mode:
             self._data = self._get_static_data()
-
-    def __unicode__(self):
-        return repr_params(('status', 'status_msg', 'count', 'version'),
-                           self.__class__.__name__, self)
-
-    def __repr__(self):
-        return self.__unicode__()
 
     @property
     def status(self):

--- a/thrall/amap/_models/_base_model.py
+++ b/thrall/amap/_models/_base_model.py
@@ -2,15 +2,15 @@
 from __future__ import absolute_import
 
 import contextlib
-import functools
 from hashlib import md5
 
 from six import iteritems
 
+from thrall.base import BaseRequestParams
 from thrall.compat import unicode, urlparse
 from thrall.consts import FORMAT_JSON, FORMAT_XML, RouteKey
-from thrall.exceptions import VendorError, amap_status_exception
-from thrall.utils import MapStatusMessage, required_params, repr_params
+from thrall.exceptions import amap_status_exception
+from thrall.utils import MapStatusMessage, repr_params
 
 from ..common import json_load_and_fix_amap_empty, parse_location
 from ..consts import AMapVersion, ExtensionFlag, OutputFmt, StatusFlag
@@ -80,53 +80,11 @@ class Sig(object):
         return prepared_sig
 
 
-class BaseRequestParams(object):
-    ROUTE_KEY = RouteKey.UNKNOWN
-
-    @required_params('key')
-    def __init__(self, key=None, output=None, private_key=None, callback=None,
-                 raw_params=None):
-        self.key = key
-        self.output = output
-        self.callback = callback
-        self.private_key = private_key
-        self._raw_params = raw_params
-
-    def prepare(self):
-        try:
-            return self.prepare_data()
-        except VendorError as err:
-            err.data = self
-            raise err
+class AMapBaseRequestParams(BaseRequestParams):
+    """amap base request params --> same as base request params"""
 
     def prepare_data(self):
-        """ package request params
-
-            input  --> Nothing
-            output --> prepared object, type_extend: BasePreparedRequestParams
-
-            override example:
-
-                def prepare(self):
-                    p = BasePreparedRequestParams()
-                    p.prepare(**some_kwargs)
-                    return p
-
-            :raise NotImplementedError: this function need to be implement.
-        """
         raise NotImplementedError
-
-    @contextlib.contextmanager
-    def prepare_basic(self, p):
-        org_fun = p.prepare
-        new_fun = functools.partial(p.prepare, key=self.key,
-                                    pkey=self.private_key,
-                                    output=self.output,
-                                    callback=self.callback,
-                                    raw_params=self._raw_params)
-        p.prepare = new_fun
-        yield p
-        p.prepare = org_fun
 
 
 class BasePreparedRequestParams(object):

--- a/thrall/amap/_models/_base_model.py
+++ b/thrall/amap/_models/_base_model.py
@@ -9,6 +9,7 @@ from thrall.base import (
     BaseRequestParams as B_RP,
     BasePreparedRequestParams as BP_RP,
     BaseResponseData as B_RD,
+    Sig as S,
 )
 from thrall.compat import unicode
 from thrall.exceptions import amap_status_exception
@@ -38,7 +39,7 @@ class Extensions(object):
         return ExtensionFlag.ALL if self._flag else ExtensionFlag.BASE
 
 
-class Sig(object):
+class AMapSig(S):
     """ AMap sig generator """
 
     def __init__(self, pkey, hash_fn=md5, kwargs=None):
@@ -54,16 +55,8 @@ class Sig(object):
         must implement digest function.
         :param kwargs: request params, same as request params.
         """
-        self.private_key = pkey
-        self.hash_func = hash_fn
+        super(AMapSig, self).__init__(pkey=pkey, hash_fn=hash_fn)
         self.kw = kwargs if kwargs is not None else {}
-
-    def __repr__(self):
-        return repr_params(['method', 'sig'],
-                           "AMap{}".format(self.__class__.__name__),
-                           self, default_value={
-                "method": self.hash_func.__name__.upper(),
-                "sig": u"'{}'".format(self.unhash_sig)})
 
     @property
     def hashed_sig(self):
@@ -100,7 +93,7 @@ class AMapBasePreparedRequestParams(BP_RP):
     @property
     def sig(self):
         if self._pkey:
-            return Sig(pkey=self._pkey, kwargs=self.generate_params())
+            return AMapSig(pkey=self._pkey, kwargs=self.generate_params())
 
     @property
     def prepared_sig(self):

--- a/thrall/amap/_models/_batch_model.py
+++ b/thrall/amap/_models/_batch_model.py
@@ -4,15 +4,15 @@ from __future__ import absolute_import
 from thrall.exceptions import amap_batch_status_exception
 
 from ._base_model import (
-    BasePreparedRequestParams,
-    BaseRequestParams,
+    AMapBasePreparedRequestParams,
+    AMapBaseRequestParams,
     BaseResponseData,
 )
 
 from thrall.utils import MapStatusMessage
 
 
-class BatchRequestParams(BaseRequestParams):
+class BatchRequestParams(AMapBaseRequestParams):
     def __init__(self, batch_list=None, key=None, url_pairs=None):
         if batch_list is None:
             batch_list = []
@@ -52,7 +52,7 @@ class BatchExcMixin(object):
         return result_list
 
 
-class PreparedBatchParams(BasePreparedRequestParams, BatchExcMixin):
+class PreparedBatchParams(AMapBasePreparedRequestParams, BatchExcMixin):
     def __init__(self, url_pairs=None):
         self.batch_list = []
         self.url_pairs = url_pairs

--- a/thrall/amap/_models/_batch_model.py
+++ b/thrall/amap/_models/_batch_model.py
@@ -6,7 +6,7 @@ from thrall.exceptions import amap_batch_status_exception
 from ._base_model import (
     AMapBasePreparedRequestParams,
     AMapBaseRequestParams,
-    BaseResponseData,
+    AmapBaseResponseData,
 )
 
 from thrall.utils import MapStatusMessage
@@ -92,7 +92,7 @@ class PreparedBatchParams(AMapBasePreparedRequestParams, BatchExcMixin):
         return {'url': url.path, 'params': params}
 
 
-class BatchResponseData(BaseResponseData, BatchExcMixin):
+class BatchResponseData(AmapBaseResponseData, BatchExcMixin):
     def __init__(self, raw_data, p, decode_pairs, static_mode=False):
         self.prepared_data = p
         self.decode_pairs = decode_pairs or {}

--- a/thrall/amap/_models/_distance_model.py
+++ b/thrall/amap/_models/_distance_model.py
@@ -16,13 +16,13 @@ from ..common import (
 )
 from ..consts import DistanceType
 from ._base_model import (
-    BasePreparedRequestParams,
-    BaseRequestParams,
+    AMapBasePreparedRequestParams,
+    AMapBaseRequestParams,
     BaseResponseData
 )
 
 
-class DistanceRequestParams(BaseRequestParams):
+class DistanceRequestParams(AMapBaseRequestParams):
     ROUTE_KEY = RouteKey.DISTANCE
 
     @required_params('origins', 'destination')
@@ -45,7 +45,7 @@ class DistanceRequestParams(BaseRequestParams):
         return p
 
 
-class PreparedDistanceRequestParams(BasePreparedRequestParams):
+class PreparedDistanceRequestParams(AMapBasePreparedRequestParams):
     ROUTE_KEY = RouteKey.DISTANCE
 
     def __init__(self):

--- a/thrall/amap/_models/_distance_model.py
+++ b/thrall/amap/_models/_distance_model.py
@@ -18,7 +18,7 @@ from ..consts import DistanceType
 from ._base_model import (
     AMapBasePreparedRequestParams,
     AMapBaseRequestParams,
-    BaseResponseData
+    AmapBaseResponseData
 )
 
 
@@ -101,7 +101,7 @@ class PreparedDistanceRequestParams(AMapBasePreparedRequestParams):
             return params
 
 
-class DistanceResponseData(BaseResponseData):
+class DistanceResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.DISTANCE
     _ROUTE = 'results'
 

--- a/thrall/amap/_models/_geo_code_model.py
+++ b/thrall/amap/_models/_geo_code_model.py
@@ -9,15 +9,15 @@ from thrall.utils import required_params
 
 from ..common import merge_multi_address, prepare_multi_address
 from ._base_model import (
-    BasePreparedRequestParams,
-    BaseRequestParams,
+    AMapBasePreparedRequestParams,
+    AMapBaseRequestParams,
     BaseResponseData,
     LocationMixin
 )
 from ._common_model import Building, Neighborhood
 
 
-class GeoCodeRequestParams(BaseRequestParams):
+class GeoCodeRequestParams(AMapBaseRequestParams):
     ROUTE_KEY = RouteKey.GEO_CODE
 
     @required_params('address')
@@ -51,7 +51,7 @@ class GeoCodeRequestParams(BaseRequestParams):
         return _p
 
 
-class PreparedGeoCodeRequestParams(BasePreparedRequestParams):
+class PreparedGeoCodeRequestParams(AMapBasePreparedRequestParams):
     ROUTE_KEY = RouteKey.GEO_CODE
 
     def __init__(self):

--- a/thrall/amap/_models/_geo_code_model.py
+++ b/thrall/amap/_models/_geo_code_model.py
@@ -11,7 +11,7 @@ from ..common import merge_multi_address, prepare_multi_address
 from ._base_model import (
     AMapBasePreparedRequestParams,
     AMapBaseRequestParams,
-    BaseResponseData,
+    AmapBaseResponseData,
     LocationMixin
 )
 from ._common_model import Building, Neighborhood
@@ -115,7 +115,7 @@ class PreparedGeoCodeRequestParams(AMapBasePreparedRequestParams):
             return params
 
 
-class GeoCodeResponseData(BaseResponseData):
+class GeoCodeResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.GEO_CODE
     _ROUTE = 'geocodes'
 

--- a/thrall/amap/_models/_navi_model.py
+++ b/thrall/amap/_models/_navi_model.py
@@ -10,13 +10,13 @@ from ..common import (
     prepare_first_location,
 )
 from ._base_model import (
-    BasePreparedRequestParams,
-    BaseRequestParams,
+    AMapBasePreparedRequestParams,
+    AMapBaseRequestParams,
     BaseResponseData,
 )
 
 
-class NavRequestParams(BaseRequestParams):
+class NavRequestParams(AMapBaseRequestParams):
 
     @required_params('origin', 'destination')
     def __init__(self, origin=None, destination=None, **kwargs):
@@ -65,7 +65,7 @@ class NaviDrivingRequestParams(NavRequestParams):
         return p
 
 
-class PreparedNaviRAndWRequestParams(BasePreparedRequestParams):
+class PreparedNaviRAndWRequestParams(AMapBasePreparedRequestParams):
     def __init__(self):
         self.origin = None
         self.destination = None

--- a/thrall/amap/_models/_navi_model.py
+++ b/thrall/amap/_models/_navi_model.py
@@ -12,7 +12,7 @@ from ..common import (
 from ._base_model import (
     AMapBasePreparedRequestParams,
     AMapBaseRequestParams,
-    BaseResponseData,
+    AmapBaseResponseData,
 )
 
 
@@ -160,7 +160,7 @@ class NaviStepsBasic(BaseData):
                     for i in polyline.split(u';')]
 
 
-class NaviRidingResponseData(BaseResponseData):
+class NaviRidingResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.NAVI_RIDING
     _ROUTE = 'data'
 
@@ -193,7 +193,7 @@ class RidingSteps(NaviStepsBasic):
                    'assistant_action')
 
 
-class NaviWalkingResponseData(BaseResponseData):
+class NaviWalkingResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.NAVI_WAKLING
     _ROUTE = 'route'
 
@@ -227,7 +227,7 @@ class WalkingSteps(NaviStepsBasic):
                    'walk_type')
 
 
-class NaviDrivingResponseData(BaseResponseData):
+class NaviDrivingResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.NAVI_DRIVING
     _ROUTE = 'route'
 

--- a/thrall/amap/_models/_regeo_code_model.py
+++ b/thrall/amap/_models/_regeo_code_model.py
@@ -16,7 +16,7 @@ from ..consts import BatchFlag, ExtensionFlag, HomeOrCorpControl, RoadLevel
 from ._base_model import (
     AMapBasePreparedRequestParams,
     AMapBaseRequestParams,
-    BaseResponseData,
+    AmapBaseResponseData,
     Extensions,
     LocationMixin
 )
@@ -203,7 +203,7 @@ class PreparedReGeoCodeRequestParams(AMapBasePreparedRequestParams):
             return params
 
 
-class ReGeoCodeResponseData(BaseResponseData):
+class ReGeoCodeResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.REGEO_CODE
 
     _ROUTE_SINGLE = 'regeocode'

--- a/thrall/amap/_models/_regeo_code_model.py
+++ b/thrall/amap/_models/_regeo_code_model.py
@@ -14,8 +14,8 @@ from ..common import (
 )
 from ..consts import BatchFlag, ExtensionFlag, HomeOrCorpControl, RoadLevel
 from ._base_model import (
-    BasePreparedRequestParams,
-    BaseRequestParams,
+    AMapBasePreparedRequestParams,
+    AMapBaseRequestParams,
     BaseResponseData,
     Extensions,
     LocationMixin
@@ -23,7 +23,7 @@ from ._base_model import (
 from ._common_model import Building, BusinessArea, Neighborhood, StreetNumber
 
 
-class ReGeoCodeRequestParams(BaseRequestParams):
+class ReGeoCodeRequestParams(AMapBaseRequestParams):
     ROUTE_KEY = RouteKey.REGEO_CODE
 
     @required_params('location')
@@ -83,7 +83,7 @@ class ReGeoCodeRequestParams(BaseRequestParams):
         return _p
 
 
-class PreparedReGeoCodeRequestParams(BasePreparedRequestParams):
+class PreparedReGeoCodeRequestParams(AMapBasePreparedRequestParams):
     ROUTE_KEY = RouteKey.REGEO_CODE
 
     def __init__(self):

--- a/thrall/amap/_models/_search_model.py
+++ b/thrall/amap/_models/_search_model.py
@@ -16,8 +16,8 @@ from ..common import (
 )
 from ..consts import ChildrenFlag, CityLimitFlag, ExtensionFlag, SortRule
 from ._base_model import (
-    BasePreparedRequestParams,
-    BaseRequestParams,
+    AMapBasePreparedRequestParams,
+    AMapBaseRequestParams,
     BaseResponseData,
     Extensions,
     LocationMixin,
@@ -25,7 +25,7 @@ from ._base_model import (
 from ._common_model import BizExt, IndoorData, Photos, Children
 
 
-class SearchTextRequestParams(BaseRequestParams):
+class SearchTextRequestParams(AMapBaseRequestParams):
     ROUTE_KEY = RouteKey.SEARCH_TEXT
 
     def __init__(self, keywords=None, types=None, city=None, city_limit=None,
@@ -80,7 +80,7 @@ class SearchTextRequestParams(BaseRequestParams):
         return p
 
 
-class SearchAroundRequestParams(BaseRequestParams):
+class SearchAroundRequestParams(AMapBaseRequestParams):
     ROUTE_KEY = RouteKey.SEARCH_AROUND
 
     @required_params('location')
@@ -204,7 +204,7 @@ class PreparedSearchMixin(object):
             return self.extensions.param
 
 
-class PreparedSearchTextRequestParams(BasePreparedRequestParams,
+class PreparedSearchTextRequestParams(AMapBasePreparedRequestParams,
                                       PreparedSearchMixin):
     ROUTE_KEY = RouteKey.SEARCH_TEXT
 
@@ -312,7 +312,7 @@ class PreparedSearchTextRequestParams(BasePreparedRequestParams,
             return params
 
 
-class PreparedSearchAroundRequestParams(BasePreparedRequestParams,
+class PreparedSearchAroundRequestParams(AMapBasePreparedRequestParams,
                                         PreparedSearchMixin):
     ROUTE_KEY = RouteKey.SEARCH_AROUND
 

--- a/thrall/amap/_models/_search_model.py
+++ b/thrall/amap/_models/_search_model.py
@@ -18,7 +18,7 @@ from ..consts import ChildrenFlag, CityLimitFlag, ExtensionFlag, SortRule
 from ._base_model import (
     AMapBasePreparedRequestParams,
     AMapBaseRequestParams,
-    BaseResponseData,
+    AmapBaseResponseData,
     Extensions,
     LocationMixin,
 )
@@ -380,7 +380,7 @@ class PreparedSearchAroundRequestParams(AMapBasePreparedRequestParams,
             return params
 
 
-class SearchResponseData(BaseResponseData):
+class SearchResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.SEARCH
 
     _SUGGESTION_ROUTE = 'suggestion'

--- a/thrall/amap/_models/_suggest_model.py
+++ b/thrall/amap/_models/_suggest_model.py
@@ -18,7 +18,7 @@ from ..consts import CityLimitFlag, DataType
 from ._base_model import (
     AMapBasePreparedRequestParams,
     AMapBaseRequestParams,
-    BaseResponseData,
+    AmapBaseResponseData,
     LocationMixin
 )
 
@@ -213,7 +213,7 @@ class PreparedSuggestRequestParams(AMapBasePreparedRequestParams):
             return params
 
 
-class SuggestResponseData(BaseResponseData):
+class SuggestResponseData(AmapBaseResponseData):
     ROUTE_KEY = RouteKey.SUGGEST
 
     _ROUTE = 'tips'

--- a/thrall/amap/_models/_suggest_model.py
+++ b/thrall/amap/_models/_suggest_model.py
@@ -16,14 +16,14 @@ from ..common import (
 )
 from ..consts import CityLimitFlag, DataType
 from ._base_model import (
-    BasePreparedRequestParams,
-    BaseRequestParams,
+    AMapBasePreparedRequestParams,
+    AMapBaseRequestParams,
     BaseResponseData,
     LocationMixin
 )
 
 
-class SuggestRequestParams(BaseRequestParams):
+class SuggestRequestParams(AMapBaseRequestParams):
     ROUTE_KEY = RouteKey.SUGGEST
 
     @required_params('keyword')
@@ -54,7 +54,7 @@ class SuggestRequestParams(BaseRequestParams):
         return p
 
 
-class PreparedSuggestRequestParams(BasePreparedRequestParams):
+class PreparedSuggestRequestParams(AMapBasePreparedRequestParams):
     ROUTE_KEY = RouteKey.SUGGEST
 
     def __init__(self):

--- a/thrall/base.py
+++ b/thrall/base.py
@@ -33,6 +33,27 @@ from .utils import builtin_names, is_func_bound, repr_params
 set_default = SetDefault
 
 
+class Sig(object):
+    def __init__(self, pkey, hash_fn):
+        self.private_key = pkey
+        self.hash_func = hash_fn
+
+    def __repr__(self):
+        return repr_params(['method', 'sig'],
+                           "AMap{}".format(self.__class__.__name__),
+                           self, default_value={
+                "method": self.hash_func.__name__.upper(),
+                "sig": u"'{}'".format(self.unhash_sig)})
+
+    @property
+    def hashed_sig(self):
+        raise NotImplementedError
+
+    @property
+    def unhash_sig(self):
+        raise NotImplementedError
+
+
 class BaseRequestParams(object):
     ROUTE_KEY = RouteKey.UNKNOWN
 

--- a/thrall/base.py
+++ b/thrall/base.py
@@ -295,6 +295,40 @@ class BaseRequest(object):
             raise VendorRequestError(str(err), data=err)
 
 
+class BaseResponseData(object):
+    ROUTE_KEY = RouteKey.UNKNOWN
+    REPR_PARAMS = ['status', 'status_msg', 'count', 'version']
+
+    def __init__(self, raw_data, version):
+        self._raw_data = raw_data
+        self.version = version
+
+    def __unicode__(self):
+        return repr_params(self.REPR_PARAMS, self.__class__.__name__, self)
+
+    def __repr__(self):
+        return self.__unicode__()
+
+    @property
+    def status(self):
+        raise NotImplementedError
+
+    @property
+    def status_msg(self):
+        raise NotImplementedError
+
+    @property
+    def count(self):
+        raise NotImplementedError
+
+    @property
+    def data(self):
+        raise NotImplementedError
+
+    def raise_for_status(self):
+        raise NotImplementedError
+
+
 class BaseData(object):
     _properties = ()
 

--- a/thrall/consts.py
+++ b/thrall/consts.py
@@ -10,6 +10,11 @@ class MapSource(IntEnum):
     BAIDU_MAP = 3
 
 
+class OutputFmt(IntEnum):
+    JSON = 1
+    XML = 2
+
+
 FORMAT_JSON = 'json'
 FORMAT_XML = 'xml'
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,12 @@ deps =
 
 [testenv:py27]
 commands =
-    pytest --cov-report term-missing --cov={envsitepackagesdir}/thrall -s --pyargs thrall tests
+    pytest --cov-report term-missing --cov={envsitepackagesdir}/thrall --pyargs thrall tests
 
 [testenv:py36]
 commands =
-    pytest --cov-report term-missing --cov={envsitepackagesdir}/thrall -s --pyargs thrall tests
+    pytest --cov-report term-missing --cov={envsitepackagesdir}/thrall --pyargs thrall tests
 
 [testenv:pypy]
 commands =
-    pytest --cov-report term-missing --cov={envsitepackagesdir}/thrall -s --pyargs thrall tests
+    pytest --cov-report term-missing --cov={envsitepackagesdir}/thrall --pyargs thrall tests


### PR DESCRIPTION
## Description

- Move `amap base request param`, `base prepared request param`, `Make amap base response` and `sig` to base module.
- deprecated basic module name in amap module.

## Todos
- [x] Tests
- [ ] ~Change log~

