### PR TITLE
Fix base data

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -110,6 +110,18 @@ class TestBaseData(object):
         assert model.c == []
         assert model.d == [1, 2]
 
+    @pytest.mark.parametrize('static', [True, False])
+    def test_set_attr(self, static):
+        raw_data = {'a': 1, 'b': '2', 'c': [], 'd': [1, 2]}
+
+        model = BaseData(raw_data, static=static)
+        model._properties = raw_data
+
+        model.a = 'xxx'
+
+        assert model.a == model.__dict__['a'] == 'xxx'
+        assert model._data['a'] == 'xxx'
+
     def test_del_attr(self):
         raw_data = {'a': 1, 'b': '2', 'c': [], 'd': [1, 2]}
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -110,6 +110,26 @@ class TestBaseData(object):
         assert model.c == []
         assert model.d == [1, 2]
 
+    def test_del_attr(self):
+        raw_data = {'a': 1, 'b': '2', 'c': [], 'd': [1, 2]}
+
+        model = BaseData(raw_data)
+        model._properties = raw_data
+
+        del model.a
+
+        assert not hasattr(model, 'a')
+
+    def test_del_attr_static(self):
+        raw_data = {'a': 1, 'b': '2', 'c': [], 'd': [1, 2]}
+
+        model = BaseData(raw_data, static=True)
+        model._properties = raw_data
+
+        del model.a
+
+        assert not hasattr(model, 'a')
+
     def test_static_data(self, mocker):
         class Mock(BaseData):
             _properties = ('a', 'b', 'c', 'd')

--- a/thrall/base.py
+++ b/thrall/base.py
@@ -104,6 +104,21 @@ class BaseData(object):
             msg = "'{0}' object has no attribute '{1}'"
             raise AttributeError(msg.format(type(self).__name__, name))
 
+    def __delattr__(self, name):
+        _get_attr = False
+
+        if name in self.__dict__:
+            _get_attr = True
+            del self.__dict__[name]
+
+        if name in self._data:
+            _get_attr = True
+            del self._data[name]
+
+        if not _get_attr:
+            msg = "'{0}' object has no attribute '{1}'"
+            raise AttributeError(msg.format(type(self).__name__, name))
+
     def _decode(self, p):
         if p not in self._properties:
             raise KeyError(p)

--- a/thrall/base.py
+++ b/thrall/base.py
@@ -104,6 +104,14 @@ class BaseData(object):
             msg = "'{0}' object has no attribute '{1}'"
             raise AttributeError(msg.format(type(self).__name__, name))
 
+    def __setattr__(self, name, value):
+        super(BaseData, self).__setattr__(name, value)
+
+        if name in ('_static', '_data'):
+            return
+
+        self._data[name] = value
+
     def __delattr__(self, name):
         _get_attr = False
 


### PR DESCRIPTION
## Description
fix `__delattr__` and `__setattr__` in base data module.

### DEL_ATTR
```Python
x = BaseData({'a': 1}, static=True/False)
x.a = 1
del a
# these call will raise TypeError 
# x.a
# x._data['a']
# x.__dict__['a']
```

### SET_ATTR
```Python
x = BaseData({'a': 1}, static=True/False)
x.a = 1
x.b = 2
assert x.b == 2
assert x._data['b'] == 2
assert x.__dict__['b'] ==2
```

## Todos
- [x] Tests
- [ ] Change log

