### PR TITLE
Add distance code return in aoi

### DIFF
--- a/thrall/amap/_models/_regeo_code_model.py
+++ b/thrall/amap/_models/_regeo_code_model.py
@@ -363,4 +363,5 @@ class ReGeoAOI(BaseData, LocationMixin):
                    'adcode',
                    'location',
                    'area',
-                   'type')
+                   'type',
+                   'distance')


### PR DESCRIPTION
## Description
see amap doc: http://lbs.amap.com/api/webservice/guide/api/georegeo
changelog: http://lbs.amap.com/api/webservice/changelog

### 高德地图 Web服务API V4.0.3 上线            2018-01-17
    我们对于逆地理编码接口的AOI进行了迭代，目前能够判断输入的经纬度是距离此AOI的距离以及是否在AOI之内。详见distance 字段

## Todos
- [ ] Tests
- [ ] Change log

